### PR TITLE
Use extern "C" instead of __BEGIN_DECL/__END_DECL macros

### DIFF
--- a/include/ion/ion.h
+++ b/include/ion/ion.h
@@ -24,7 +24,9 @@
 #include <sys/types.h>
 #include <linux/ion.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 int ion_open();
 int ion_close(int fd);
@@ -34,6 +36,8 @@ int ion_free(int fd, int handle_fd);
 int ion_query_heap_cnt(int fd, int* cnt);
 int ion_query_get_heaps(int fd, int cnt, void* buffers);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ION_H */


### PR DESCRIPTION
these macros are defined in sys/cdefs.h for glibc and this header is not available on all libc

for glibc they are defined like below

Signed-off-by: Khem Raj <raj.khem@gmail.com>